### PR TITLE
Fix multiple params passed to method, which is calling on #within

### DIFF
--- a/lib/kameleon/dsl.rb
+++ b/lib/kameleon/dsl.rb
@@ -41,6 +41,10 @@ module Kameleon
       Kameleon::Session.new(name).tap { |ks| act_as(ks.name) }
     end
 
+    def create_sessions(*names)
+      names.each { |n| create_session(n) }
+    end
+
     def act_as(name)
       if block_given?
         using_session(name) do

--- a/lib/kameleon/dsl.rb
+++ b/lib/kameleon/dsl.rb
@@ -102,9 +102,9 @@ module Kameleon
     class ScopeProxy < Struct.new(:world, :scope)
 
       Kameleon::DSL.instance_methods.each do |method|
-        define_method method do |args|
+        define_method method do |*args|
           world.within(scope) do
-            world.send(method, args)
+            world.send(method, *args)
           end
         end
       end

--- a/spec/integration/context/scope_spec.rb
+++ b/spec/integration/context/scope_spec.rb
@@ -35,6 +35,13 @@ describe 'Scope' do
         within("ul#menu").see 7 => "li"
       end
 
+      context 'with many parameters passed to methods' do
+        it 'see' do
+          within('#main').see 'Left side', 'Right side'
+          within('#footer').not_see 'Left side', 'Right side'
+        end
+      end
+
       context "errors" do
         it "raise when element not found" do
           expect do
@@ -42,8 +49,8 @@ describe 'Scope' do
           end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
         end
       end
-    end
 
+    end
   end
 
   describe "defined areas" do

--- a/spec/integration/context/session_spec.rb
+++ b/spec/integration/context/session_spec.rb
@@ -36,6 +36,36 @@ describe "Session" do
     end
   end
 
+  describe 'creating multiple sessions at once' do
+    before do
+      create_sessions(:admin, :user)
+      visit '/'
+    end
+
+    it 'should work on the last created session by default' do
+      not_see 'This is simple app', 'in that app'
+      see 'Home'
+
+      act_as(:user) do
+        not_see 'This is simple app', 'in that app'
+        see 'Home'
+      end
+    end
+
+    it 'should work on all created sessions' do
+      act_as(:admin) do
+        visit '/texts'
+        see 'This is simple app', 'in that app'
+        not_see 'Home'
+      end
+
+      act_as(:user) do
+        not_see 'This is simple app', 'in that app'
+        see 'Home'
+      end
+    end
+  end
+
   describe "Drivers" do
 
   end


### PR DESCRIPTION
For example, when I called the method:

``` ruby
within(:my_scope).see 'foo', 'bar'
```

I received the following error:

```
ArgumentError:
  wrong number of arguments (2 for 1).
```

This is, because param "args" hadn't asterisk..:

``` ruby
Kameleon::DSL.instance_methods.each do |method|
  define_method method do |args|
    define_method method do |*args| # here should be asterisk
      world.within(scope) do
        world.send(method, args)
        world.send(method, *args) # and here
        # (...)
```
