### PR TITLE
Fix multiple params passed to method, which is calling on #within(:scope).

### DIFF
--- a/lib/kameleon/dsl.rb
+++ b/lib/kameleon/dsl.rb
@@ -98,9 +98,9 @@ module Kameleon
     class ScopeProxy < Struct.new(:world, :scope)
 
       Kameleon::DSL.instance_methods.each do |method|
-        define_method method do |args|
+        define_method method do |*args|
           world.within(scope) do
-            world.send(method, args)
+            world.send(method, *args)
           end
         end
       end

--- a/spec/integration/context/scope_spec.rb
+++ b/spec/integration/context/scope_spec.rb
@@ -35,6 +35,13 @@ describe 'Scope' do
         within("ul#menu").see 7 => "li"
       end
 
+      context 'with many parameters passed to method' do
+        it 'see' do
+          within('#main').see 'Left side', 'Right side'
+          within('#footer').not_see 'Left side', 'Right side'
+        end
+      end
+
       context "errors" do
         it "raise when element not found" do
           expect do


### PR DESCRIPTION
For example, when I called the method:

``` ruby
within(:my_scope).see 'foo', 'bar'
```

I received the following error:

```
ArgumentError:
  wrong number of arguments (2 for 1).
```

This is, because param "args" hadn't asterisk..:

``` ruby
Kameleon::DSL.instance_methods.each do |method|
  define_method method do |args|
    define_method method do |*args| # here should be asterisk
      world.within(scope) do
        world.send(method, args)
        world.send(method, *args) # and here
        # (...)
```
