### PR TITLE
Add possibility to calling #create_session method with block.

### DIFF
--- a/lib/kameleon/dsl.rb
+++ b/lib/kameleon/dsl.rb
@@ -38,7 +38,11 @@ module Kameleon
     end
 
     def create_session(name = :default)
-      Kameleon::Session.new(name).tap { |ks| act_as(ks.name) }
+      Kameleon::Session.new(name).tap do |session|
+        act_as(session.name).tap do
+          yield if block_given?
+        end
+      end
     end
 
     def act_as(name)

--- a/spec/integration/context/session_spec.rb
+++ b/spec/integration/context/session_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 describe "Session" do
+  describe '#create_session' do
+    describe 'with block' do
+      it 'should run passed block' do
+        create_session(:user) do
+          visit('/texts')
+          see 'This is simple app', 'in that app'
+          not_see 'Home'
+        end
+
+        act_as :user do
+          see 'This is simple app', 'in that app'
+          not_see 'Home'
+        end
+      end
+    end
+  end
+
   describe "switch" do
     before do
       # we use :default session


### PR DESCRIPTION
When I create new session and I want to do something on it - I would like to use #create_session with block, i.e.:

``` ruby
create_session :admin do
  visit '/admin'
  click 'Login'
  fill_in 'admin' => 'username'
end

create_session :customer do
  visit '/customer'
  click 'Login'
  fill_in 'customer' => 'username'
end
```

For me it better looks (even if above example has got more lines of code than below, because I see what is doing in the specific session) - than:

``` ruby
create_session :admin
visit '/admin'
click 'Login'
fill_in 'admin' => 'username'

create_session :customer
visit '/customer'
click 'Login'
fill_in 'customer' => 'username'
```
