### PR TITLE
custom spec directories structure

### DIFF
--- a/lib/kameleon/ext/rspec/dsl.rb
+++ b/lib/kameleon/ext/rspec/dsl.rb
@@ -9,7 +9,7 @@ RSpec.configure do |config|
   def config.escaped_path(*parts)
     Regexp.compile(parts.join('[\\\/]'))
   end
-  escaped_group_file_path = config.escaped_path(%w[spec (requests|integration)])
+  escaped_group_file_path = config.escaped_path(%w[spec .*(requests|integration|acceptance)])
 
   config.include Capybara::DSL, :type => :request, :example_group => {:file_path => escaped_group_file_path}
   config.include Kameleon::DSL, :type => :request, :example_group => {:file_path => escaped_group_file_path}


### PR DESCRIPTION
it should handle custom directories like
spec/acceptance/.*
spec/some/path/acceptance/.*
spec/integration/.*
spec/some/path/integration/.*
spec/requests/.*
spec/some/path/requests/.*

When use such directories structure, kameleon fails with errors like "undefined method visit"
After this patch it may also fail if rails url helpers are used. To fix this issue, add  
include Rails.application.routes.url_helpers
to describe block
